### PR TITLE
Add the new valueFormat 'moment'

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ Default: `X`
 
 This is the format in which the date is passed back to the controller.
 
-This format must be one of the momentjs defined formats, or be set to 'date' to
-be recognised as a Javascript Date object.
+This format must be one of the following:
+* momentjs defined formats (http://momentjs.com/docs/#/parsing/string-format/)
+* 'date' to be recognised as a Javascript Date object.
+* 'moment' to be recognised as a Momentjs object.
 
 #### format
 Type: `String`

--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -92,6 +92,8 @@ export default Em.TextField.extend({
       // update date value with user selected date with consistent format
       if (this.get('valueFormat') === 'date') {
         d = d.toDate();
+      } else if (this.get('valueFormat') === 'moment') {
+        // just set date as a moment object
       } else {
         d = d.format(this.get('valueFormat'));
       }
@@ -125,6 +127,8 @@ export default Em.TextField.extend({
       // serialize moment.js date either from plain date object or string
       if (this.get('valueFormat') === 'date') {
         d = window.moment(this.get('date'));
+      } else if (this.get('valueFormat') === 'moment') {
+        d = this.get('date');
       } else {
         d = window.moment(this.get('date'), this.get("valueFormat"));
       }

--- a/tests/unit/date-picker-component-test.js
+++ b/tests/unit/date-picker-component-test.js
@@ -178,6 +178,23 @@ test("it respects `valueFormat: 'date'` when setting date value", function() {
   });
 });
 
+test("it respects `valueFormat: 'moment'` when setting date value", function() {
+  expect(1);
+  component = this.subject({
+    valueFormat: 'moment'
+  });
+
+  fillIn(this.$(), "2000-01-01");
+
+  andThen(function() {
+    // simulate open + close of picker
+    component.get('_picker').show();
+    component.get('_picker').hide();
+
+    equal(component.get('date').format(), moment("2000-01-01").format(), "sets correct moment object");
+  });
+});
+
 test("it respects `valueFormat` when setting date value", function() {
   expect(1);
   component = this.subject({


### PR DESCRIPTION
This feature will set 'date' as a moment object
instead of string.